### PR TITLE
Updated to ghc-8.0.x

### DIFF
--- a/cabal-info.cabal
+++ b/cabal-info.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                cabal-info
-version:             0.1.0.0
+version:             0.2.1
 synopsis:            Read information from cabal files
 description:
   Have you ever needed to get information from a cabal file in a shell
@@ -37,7 +37,7 @@ source-repository this
 
 library
   exposed-modules:  Cabal.Info
-  build-depends:    base >=4.8 && <4.9
+  build-depends:    base >=4.8 && <5
                   , Cabal
                   , directory
                   , filepath
@@ -50,7 +50,7 @@ executable cabal-info
   other-modules:    Args
                   , Describe
                   , Fields
-  build-depends:    base >=4.8 && <4.9
+  build-depends:    base >=4.8 && <5
                   , cabal-info
                   , Cabal
                   , filepath

--- a/cabal-info/Args.hs
+++ b/cabal-info/Args.hs
@@ -2,6 +2,7 @@
 module Args where
 
 import Data.Char (toLower)
+import Data.Monoid ((<>))
 import Options.Applicative
 import Distribution.PackageDescription (FlagAssignment, FlagName(..))
 import Distribution.System (Arch(..), OS(..))

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-4.2
+resolver: lts-8.13


### PR DESCRIPTION
This allows for compilation with ghc-8. I use it for reading `build-depends` which are sometimes ghc `impl` specific and switched by flags, requiring a ghc-8-built `cabal-info`